### PR TITLE
Added support for window targeting (example: '_blank')

### DIFF
--- a/jquery.redirect.js
+++ b/jquery.redirect.js
@@ -1,26 +1,30 @@
 /* jQuery POST/GET redirect method
+   v.0.1.1
+	modified by CJ Carr, https://github.com/cortexelus
    v.0.1
-	modified by Miguel Galante,https://github.com/mgalante
+	modified by Miguel Galante, https://github.com/mgalante
    v.0.1
-   made by Nemanja Avramovic, www.avramovic.info 
+   made by Nemanja Avramovic, http://www.avramovic.info 
    */
 
 ;(function( $ ){
 
-	$.redirect = function( target, values, method ) {  
+	$.redirect = function( url, values, method, target ) {  
 
 		method = (method && method.toUpperCase() == 'GET') ? 'GET' : 'POST';
-			
+		target = typeof target == "string" ? target : ""
+
 		if (!values)
 		{
-			var obj = $.parse_url(target);
-			target = obj.url;
+			var obj = $.parse_url(url);
+			url = obj.url;
 			values = obj.params;
 		}
 					
 		var form = $('<form>',{attr:{
 			method: method,
-			action: target
+			action: url,
+			target: target
 		}});
 		
 		for(var i in values)


### PR DESCRIPTION
#### Window targets ####
Now redirect can target windows
```
$.redirect('create-knowledge-asset.php', data, 'POST', '_blank');
````
This will open a new window and post data to it. 

##### Backwards compatible #####
If the last argument is left out, it becomes empty string, which is default behavior (redirect in same window).
```
$.redirect('create-knowledge-asset.php', data, 'POST');
````

##### target #####
The previously-named variable *target* was renamed *url* to avoid confusion, because in &lt;form&gt; the *target* attribute refers to a window.
```
<form ... target="_blank">
``` 