### PR TITLE
Fixing formatting arrays containing objects

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "jquery.redirect",
   "main": "jquery.redirect.js",
   "ignore": [],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://github.com/mgalante/jquery.redirect.git",
   "authors": [
     "Miguel Galante",

--- a/jquery.redirect.js
+++ b/jquery.redirect.js
@@ -105,7 +105,11 @@ ShareAlike - If you remix, transform, or build upon the material, you must distr
         for (i in values) {
             if (typeof values[i] === "object") {
                 iterateParent = parent.slice();
-                iterateParent.push(i);
+                if (array) {
+                  iterateParent.push('');
+                } else {
+                  iterateParent.push(i);
+                }
                 iterateValues(values[i], iterateParent, form, Array.isArray(values[i]));
             } else {
                 form.append(getInput(i, values[i], parent, array));

--- a/jquery.redirect.js
+++ b/jquery.redirect.js
@@ -1,5 +1,5 @@
 /*
-jQuery Redirect v1.0.0
+jQuery Redirect v1.0.1
 
 Copyright (c) 2013-2015 Miguel Galante
 Copyright (c) 2011-2013 Nemanja Avramovic, www.avramovic.info


### PR DESCRIPTION
**Before:** Arrays containing objects would be transmitted as objects themselves, i.e.
```javascript
{
  "key": [{
    "nested_object": "value"
  }]
}
```

would be processed by some servers as:
```javascript
{
  "key": {
    "0": {
      "nested_object": "value"
    }
  }
}
```

This fixes the formatting of those values.

I have another branch containing some tests, which I'll submit as a separate PR in case you don't want the bloat.