### PR TITLE
Add package.json for npm/yarn installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "jquery.redirect",
+  "version": "1.0.7",
+  "description": "jQuery Redirect Plugin",
+  "main": "jquery.redirect.js",
+  "author": "Miguel Galante, Nemanja Avramovic",
+  "homepage": "https://github.com/mgalante/jquery.redirect",
+  "license": "CC BY-SA 4.0"
+}


### PR DESCRIPTION
Dear Miguel,

first things first: Thanks for conceiving and maintaining this little but valuable jQuery plugin!

We added a `package.json` file for making things like `yarn add https://github.com/mgalante/jquery.redirect` possible. It currently reflects the content of the `bower.json` file you already have in the source tree.

Would you consider merging this minor improvement? It would make it easier to use the module from npm and yarn.

With kind regards,
Andreas.
